### PR TITLE
Increase template creation timeout

### DIFF
--- a/proxstar/tasks.py
+++ b/proxstar/tasks.py
@@ -95,7 +95,12 @@ def delete_vm_task(vmid):
         starrs = connect_starrs()
         vm = VM(vmid)
         # do this before deleting the VM since it is hard to reconcile later
-        delete_starrs(starrs, vm.name)
+        retry = 0
+        while retry < 3:
+            try:
+                delete_starrs(starrs, vm.name)
+            except:
+                continue
         if vm.status != 'stopped':
             vm.stop()
             retry = 0
@@ -167,7 +172,7 @@ def setup_template_task(template_id, name, user, ssh_key, cores, memory):
         while retry < timeout:
             if not VM(vmid).is_provisioned():
                 retry += 1
-                time.sleep(3)
+                time.sleep(6)
                 continue
             break
         if retry == timeout:


### PR DESCRIPTION
After talking with @com6056 we figured out creation with templates was failing because we only allow 60 seconds for the template VM to clone. If it took longer the VM should be de-provisioned, but the lack of a STARRS record caused that to fail, leaving the VM in a state where the template had been copied but proxstar has given up on applying the cloud-init config, so the VM is left without networking or login
This doubles the amount of time proxstar has to apply the config, which is hopefully enough to succeed. Also, deleting VMs shouldn't fail if there's no STARRS entry.