### PR TITLE
Set default creation pool to current user

### DIFF
--- a/proxstar/templates/create.html
+++ b/proxstar/templates/create.html
@@ -72,7 +72,7 @@
                         <label for="user" class="pull-left">User</label>
                         <select name="user" id="user" class="form-control">
                             {% for pool in pools %}
-                            <option value="{{ pool }}">{{ pool }}</option>
+                            <option value="{{ pool }}" {{ "selected" if user.name == pool else "" }}>{{ pool }}</option>
                             {% endfor %}
                         </select>
                     </div>


### PR DESCRIPTION
RTPs get to create vms in any pool, and the default in the user creation list is not the current user, but the first pool returned (in practice, alphabetically). Setting 'selected' on the option should remove this small inconvenience.

Completely untested, I wrote this in the webui, but it seems like it will _probably_ not break everything.

Resolves #41 