### PR TITLE
Add "Owned by <user>" as starrs comment

### DIFF
--- a/proxstar/starrs.py
+++ b/proxstar/starrs.py
@@ -90,6 +90,10 @@ def register_starrs(starrs, name, owner, mac, addr):
             (name, owner, 'members', mac, addr, 'csh.rit.edu', 'dhcp', True))
         results = c.fetchall()
         c.execute('COMMIT')
+        c.execute('BEGIN')
+        c.callproc('api.initialize', ('root', ))
+        c.callproc('api.modify_system', (name, 'comment', f'Owned by {owner}'))
+        c.execute('COMMIT')
     finally:
         c.close()
     return results


### PR DESCRIPTION
It'd be nice to have more information about who's responsible for an address in starrs without having to switch to proxstar and look it up. This adds that in the "comment" column when creating a system, so that future systems will include this data.

Caveat: I'm not setup to test proxstar with starrs quite yet. I'm [api.modify_system](https://github.com/cohoe/starrs/blob/0caa585532af6eedcc7e916cde1a71fe302f3ca0/API/Systems/api_systems_modify.sql#L6), and would appreciate a review @com6056 since I've not touched stored procedures before.