### PR TITLE
Update from raven to sentry and add sentry envs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,7 @@
 [MASTER]
 ignore = ,input
 persistent = yes
+load-plugins = pylint_quotes
 
 [MESSAGES CONTROL]
 disable =

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install:
   - "pip install -r requirements.txt"
 script:
-  - "pylint --load-plugins pylint_quotes proxstar"
+  - "pylint proxstar"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It is available to house members at [proxstar.csh.rit.edu](https://proxstar.csh.
 1. [Fork](https://help.github.com/en/articles/fork-a-repo) this repository
     - Optionally create a new [git branch](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell) if your change is more than a small tweak (`git checkout -b BRANCH-NAME-HERE`)
 3. Make your changes locally, commit, and push to your fork
+    - If you want to test locally, you should copy `config.py` to `config_local.py`, and talk to an RTP about filling in secrets.
 4. Create a [Pull Request](https://help.github.com/en/articles/about-pull-requests) on this repo for our Webmasters to review
 
 ## Questions/Concerns

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ It is available to house members at [proxstar.csh.rit.edu](https://proxstar.csh.
 ## Contributing
 
 1. [Fork](https://help.github.com/en/articles/fork-a-repo) this repository
-    - Optionally create a new [git branch](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell) if your change is more than a small tweak (`git checkout -b BRANCH-NAME-HERE`)
+  - Optionally create a new [git branch](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell) if your change is more than a small tweak (`git checkout -b BRANCH-NAME-HERE`)
 3. Make your changes locally, commit, and push to your fork
-    - If you want to test locally, you should copy `config.py` to `config_local.py`, and talk to an RTP about filling in secrets.
+  - If you want to test locally, you should copy `config.py` to `config_local.py`, and talk to an RTP about filling in secrets.
+  - Lint your local changes with `pylint proxstar`
+    - You'll need dependencies installed locally to do this. You should do that in a [venv](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) of some sort to keep your system clean. All the dependencies are listed in [requirements.txt](./requirements.txt), so you can install everything with `pip install -r requirements.txt`. You'll need python 3.6 at minimum, though things should work up to python 3.8.
 4. Create a [Pull Request](https://help.github.com/en/articles/about-pull-requests) on this repo for our Webmasters to review
 
 ## Questions/Concerns

--- a/config.py
+++ b/config.py
@@ -60,3 +60,10 @@ WEBSOCKIFY_PATH = environ.get('PROXSTAR_WEBSOCKIFY_PATH',
                               '/opt/app-root/bin/websockify')
 WEBSOCKIFY_TARGET_FILE = environ.get('PROXSTAR_WEBSOCKIFY_TARGET_FILE',
                                      '/opt/app-root/src/targets')
+
+# SENTRY
+# Do not set the DSN for local development
+SENTRY_DSN = environ.get("CONDITIONAL_SENTRY_DSN", "")
+SENTRY_CONFIG = {
+    'dsn': environ.get("CONDITIONAL_SENTRY_DSN", "")
+}

--- a/config.py
+++ b/config.py
@@ -64,6 +64,3 @@ WEBSOCKIFY_TARGET_FILE = environ.get('PROXSTAR_WEBSOCKIFY_TARGET_FILE',
 # SENTRY
 # Do not set the DSN for local development
 SENTRY_DSN = environ.get("CONDITIONAL_SENTRY_DSN", "")
-SENTRY_CONFIG = {
-    'dsn': environ.get("CONDITIONAL_SENTRY_DSN", "")
-}

--- a/config.py
+++ b/config.py
@@ -62,5 +62,7 @@ WEBSOCKIFY_TARGET_FILE = environ.get('PROXSTAR_WEBSOCKIFY_TARGET_FILE',
                                      '/opt/app-root/src/targets')
 
 # SENTRY
-# Do not set the DSN for local development
-SENTRY_DSN = environ.get("CONDITIONAL_SENTRY_DSN", "")
+# If you set the sentry dsn locally, make sure you use the local-dev or some
+# other local environment, so we can separate local errors from production
+SENTRY_DSN = environ.get("PROXSTAR_SENTRY_DSN", "")
+SENTRY_ENV = environ.get("PROXSTAR_SENTRY_ENV", "local-dev")

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -35,9 +35,9 @@ app = Flask(__name__)
 app.config.from_object(rq_dashboard.default_settings)
 if os.path.exists(
         os.path.join(
-            app.config.get('ROOT_DIR', os.getcwd()), 'config.local.py')):
+            app.config.get('ROOT_DIR', os.getcwd()), 'config_local.py')):
     config = os.path.join(
-        app.config.get('ROOT_DIR', os.getcwd()), 'config.local.py')
+        app.config.get('ROOT_DIR', os.getcwd()), 'config_local.py')
 else:
     config = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'config.py')
 app.config.from_pyfile(config)

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -13,6 +13,10 @@ from rq_scheduler import Scheduler
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from flask import Flask, render_template, request, redirect, session, abort, url_for
+from raven.contrib.flask import Sentry
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from proxstar.db import (Base, datetime, get_pool_cache, renew_vm_expire, set_user_usage_limits, get_template,
                          get_templates, get_allowed_users, add_ignored_pool, delete_ignored_pool, add_allowed_user,
                          delete_allowed_user,
@@ -39,7 +43,12 @@ else:
 app.config.from_pyfile(config)
 app.config['GIT_REVISION'] = subprocess.check_output(
     ['git', 'rev-parse', '--short', 'HEAD']).decode('utf-8').rstrip()
-
+# Sentry setup
+sentry = Sentry(app)
+sentry_sdk.init(
+    dsn=app.config['SENTRY_DSN'],
+    integrations=[FlaskIntegration(), SqlalchemyIntegration()]
+)
 with open('proxmox_ssh_key', 'w') as ssh_key_file:
     ssh_key_file.write(app.config['PROXMOX_SSH_KEY'])
 

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -47,7 +47,8 @@ app.config['GIT_REVISION'] = subprocess.check_output(
 # Sentry setup
 sentry_sdk.init(
     dsn=app.config['SENTRY_DSN'],
-    integrations=[FlaskIntegration(), RqIntegration(), SqlalchemyIntegration()]
+    integrations=[FlaskIntegration(), RqIntegration(), SqlalchemyIntegration()],
+    environment=app.config['SENTRY_ENV']
 )
 
 with open('proxmox_ssh_key', 'w') as ssh_key_file:

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import sessionmaker
 from flask import Flask, render_template, request, redirect, session, abort, url_for
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations.rq import RqIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from proxstar.db import (Base, datetime, get_pool_cache, renew_vm_expire, set_user_usage_limits, get_template,
                          get_templates, get_allowed_users, add_ignored_pool, delete_ignored_pool, add_allowed_user,
@@ -42,11 +43,13 @@ else:
 app.config.from_pyfile(config)
 app.config['GIT_REVISION'] = subprocess.check_output(
     ['git', 'rev-parse', '--short', 'HEAD']).decode('utf-8').rstrip()
+
 # Sentry setup
 sentry_sdk.init(
     dsn=app.config['SENTRY_DSN'],
-    integrations=[FlaskIntegration(), SqlalchemyIntegration()]
+    integrations=[FlaskIntegration(), RqIntegration(), SqlalchemyIntegration()]
 )
+
 with open('proxmox_ssh_key', 'w') as ssh_key_file:
     ssh_key_file.write(app.config['PROXMOX_SSH_KEY'])
 

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -13,7 +13,6 @@ from rq_scheduler import Scheduler
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from flask import Flask, render_template, request, redirect, session, abort, url_for
-from raven.contrib.flask import Sentry
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -44,7 +43,6 @@ app.config.from_pyfile(config)
 app.config['GIT_REVISION'] = subprocess.check_output(
     ['git', 'rev-parse', '--short', 'HEAD']).decode('utf-8').rstrip()
 # Sentry setup
-sentry = Sentry(app)
 sentry_sdk.init(
     dsn=app.config['SENTRY_DSN'],
     integrations=[FlaskIntegration(), SqlalchemyIntegration()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tenacity==5.0.2
 websockify==0.8.0
 pylint==2.3.1
 pylint-quotes==0.2.1
+sentry-sdk~=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ proxmoxer==1.0.3
 psutil==5.6.6
 psycopg2-binary==2.8.6
 python-dateutil==2.7.3
-raven~=6.10.0
 redis==2.10.6
 requests==2.20.1
 rq==0.12.0
@@ -19,4 +18,5 @@ tenacity==5.0.2
 websockify==0.8.0
 pylint==2.3.1
 pylint-quotes==0.2.1
-sentry-sdk~=0.13.1
+sentry-sdk[flask]
+sentry-sdk~=0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gunicorn==19.9.0
 paramiko==2.4.2
 proxmoxer==1.0.3
 psutil==5.6.6
-psycopg2-binary==2.7.5
+psycopg2-binary==2.8.6
 python-dateutil==2.7.3
 raven~=6.10.0
 redis==2.10.6

--- a/rqsettings.py
+++ b/rqsettings.py
@@ -10,5 +10,6 @@ else:
 
 sentry_sdk.init(
     config.SENTRY_DSN,
-    integrations=[RqIntegration()]
+    integrations=[RqIntegration()],
+    environment=config.SENTRY_ENV
 )

--- a/rqsettings.py
+++ b/rqsettings.py
@@ -3,7 +3,12 @@ import os
 import sentry_sdk
 from sentry_sdk.integrations.rq import RqIntegration
 
+if os.path.exists('config_local.py'):
+    import config_local as config
+else:
+    import config
+
 sentry_sdk.init(
-    os.environ.get('PROXSTAR_SENTRY_DSN'),
+    config.SENTRY_DSN,
     integrations=[RqIntegration()]
 )

--- a/rqsettings.py
+++ b/rqsettings.py
@@ -1,0 +1,9 @@
+import os
+
+import sentry_sdk
+from sentry_sdk.integrations.rq import RqIntegration
+
+sentry_sdk.init(
+    os.environ.get('PROXSTAR_SENTRY_DSN'),
+    integrations=[RqIntegration()]
+)

--- a/start_worker.sh
+++ b/start_worker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/opt/app-root/bin/rq worker -u "$PROXSTAR_REDIS_URL" --sentry-dsn "$PROXSTAR_SENTRY_DSN"
+/opt/app-root/bin/rq worker -u "$PROXSTAR_REDIS_URL" --sentry-dsn "" -c rqsettings


### PR DESCRIPTION
This fixes #27, and is based off of #32, which was reverted in #33. Since this fixes blinker, it shouldn't experience the same issues #32 did.

Fixed the blinker warning by installing sentry with the flask option, and did sentry setup for rq.

Tested (as far as I currently can) locally: passes pylint, rq starts, 
- [x] pylint passes
- [x] rq worker starts and can connect to local redis
- [x] the webapp starts and gets past sentry init (though it dies when it tries to connect to the db because I don't have full local dev)

I also did a bit of other cleanup
- Better local dev experience on py3.8 (no more psycopg2-binary errors on install)
- Cleaner pylint (load plugins in the pylintrc, thanks to Galen for pointing out that this is a thing)
- Deleted raven from requirements
- Added environment configs for sentry so that if someone does do local sentry, it will work
  - Already added to the deployment environment, so these should be good to go
