### PR TITLE
Updating csh-ldap and rq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ rrd/*
 *.pyc
 *_key
 Pipfile*
+
+# venv parts
+bin
+pyvenv.cfg
+site-packages
+venv

--- a/config.py
+++ b/config.py
@@ -64,5 +64,6 @@ WEBSOCKIFY_TARGET_FILE = environ.get('PROXSTAR_WEBSOCKIFY_TARGET_FILE',
 # SENTRY
 # If you set the sentry dsn locally, make sure you use the local-dev or some
 # other local environment, so we can separate local errors from production
-SENTRY_DSN = environ.get("PROXSTAR_SENTRY_DSN", "")
-SENTRY_ENV = environ.get("PROXSTAR_SENTRY_ENV", "local-dev")
+SENTRY_DSN = environ.get('PROXSTAR_SENTRY_DSN', '')
+RQ_SENTRY_DSN = environ.get('PROXSTAR_SENTRY_DSN', '')
+SENTRY_ENV = environ.get('PROXSTAR_SENTRY_ENV', 'local-dev')

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -450,7 +450,7 @@ def create():
                             memory,
                             disk,
                             iso,
-                            timeout=300)
+                            job_timeout=300)
                     else:
                         q.enqueue(
                             setup_template_task,
@@ -460,7 +460,7 @@ def create():
                             ssh_key,
                             cores,
                             memory,
-                            timeout=600)
+                            job_timeout=600)
                         return '', 200
             return '', 200
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-csh-ldap==2.1.1
+csh-ldap~=2.2.0
 flask==1.0.2
 flask-pyoidc==1.3.0
 gunicorn==19.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,11 @@ proxmoxer==1.0.3
 psutil==5.6.6
 psycopg2-binary==2.8.6
 python-dateutil==2.7.3
-redis==2.10.6
+redis==3.5.3
 requests==2.24.0
-rq==0.12.0
-rq-dashboard==0.4.0
-rq-scheduler==0.8.3
+rq==1.1.0
+rq-dashboard==0.6.1
+rq-scheduler==0.10.0
 sqlalchemy==1.3.20
 sshtunnel==0.2.2
 tenacity==5.0.2


### PR DESCRIPTION
Updating important packages in rq and csh-ldap

- `csh-ldap` should be a safe update
- `rq` may not be, but, we should move up and fix incompatibilities. Especially since rq uses outdated sentry sdk