### PR TITLE
Enrich Sentry traces using a basic repr

### DIFF
--- a/proxstar/models.py
+++ b/proxstar/models.py
@@ -3,15 +3,19 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.types import JSON, Text
 
+from proxstar.util import default_repr
+
 Base = declarative_base()
 
 
+@default_repr
 class VM_Expiration(Base):
     __tablename__ = 'vm_expiration'
     id = Column(Integer, primary_key=True)
     expire_date = Column(Date, nullable=False)
 
 
+@default_repr
 class Usage_Limit(Base):
     __tablename__ = 'usage_limit'
     id = Column(String(32), primary_key=True)
@@ -20,6 +24,7 @@ class Usage_Limit(Base):
     disk = Column(Integer, nullable=False)
 
 
+@default_repr
 class Pool_Cache(Base):
     __tablename__ = 'pool_cache'
     pool = Column(String(32), primary_key=True)
@@ -30,6 +35,7 @@ class Pool_Cache(Base):
     percents = Column(JSON, nullable=False)
 
 
+@default_repr
 class Template(Base):
     __tablename__ = 'template'
     id = Column(Integer, primary_key=True)
@@ -37,11 +43,13 @@ class Template(Base):
     disk = Column(Integer, nullable=False)
 
 
+@default_repr
 class Ignored_Pools(Base):
     __tablename__ = 'ignored_pools'
     id = Column(String(32), primary_key=True)
 
 
+@default_repr
 class Allowed_Users(Base):
     __tablename__ = 'allowed_users'
     id = Column(String(32), primary_key=True)

--- a/proxstar/user.py
+++ b/proxstar/user.py
@@ -5,10 +5,11 @@ from proxstar.ldapdb import is_active, is_user, is_current_student
 from proxstar import db, q, redis_conn
 from proxstar.db import get_allowed_users, get_user_usage_limits, is_rtp
 from proxstar.proxmox import connect_proxmox, get_pools
-from proxstar.util import lazy_property
+from proxstar.util import lazy_property, default_repr
 from proxstar.vm import VM
 
 
+@default_repr
 class User:
     def __init__(self, username):
         self.name = username

--- a/proxstar/util.py
+++ b/proxstar/util.py
@@ -19,3 +19,20 @@ def lazy_property(fn):
         return getattr(self, attr_name)
 
     return _lazy_property
+
+
+def default_repr(cls):
+    """
+    Add a default repr to a class in the form of
+    ```
+    Class(field1=val1, field2=val2...)
+    ```
+    """
+
+    def __repr__(self):
+        fields = [f'{key}={val}' for key, val in self.__dict__.items()]
+        return f'{type(self).__name__}({", ".join(fields)})'
+
+    setattr(cls, '__repr__', __repr__)
+
+    return cls

--- a/proxstar/vm.py
+++ b/proxstar/vm.py
@@ -8,9 +8,10 @@ from proxstar import db, starrs
 from proxstar.db import delete_vm_expire, get_vm_expire
 from proxstar.proxmox import connect_proxmox, get_free_vmid, get_node_least_mem, get_vm_node
 from proxstar.starrs import get_ip_for_mac
-from proxstar.util import lazy_property
+from proxstar.util import lazy_property, default_repr
 
 
+@default_repr
 class VM:
     def __init__(self, vmid):
         self.id = vmid


### PR DESCRIPTION
Sentry traces with `VM object at <memory address>` are annoying and less helpful.

This PR creates the `default_repr` class decorator which just prints a simple listing of all fields.

