### PR TITLE
Boot Ordering and other fixes

### DIFF
--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -406,7 +406,7 @@ def delete(vmid):
 
 @app.route('/vm/<string:vmid>/boot_order', methods=['POST'])
 @auth.oidc_auth
-def get_boot_order(vmid):
+def set_boot_order(vmid):
     user = User(session['userinfo']['preferred_username'])
     connect_proxmox()
     if user.rtp or int(vmid) in user.allowed_vms:

--- a/proxstar/tasks.py
+++ b/proxstar/tasks.py
@@ -27,8 +27,8 @@ from proxstar.vnc import send_stop_ssh_tunnel
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.INFO)
 
 app = Flask(__name__)
-if os.path.exists(os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'config.local.py')):
-    config = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'config.local.py')
+if os.path.exists(os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'config_local.py')):
+    config = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'config_local.py')
 else:
     config = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), 'config.py')
 app.config.from_pyfile(config)

--- a/proxstar/tasks.py
+++ b/proxstar/tasks.py
@@ -90,6 +90,7 @@ def create_vm_task(user, name, cores, memory, disk, iso):
         register_starrs(starrs, name, app.config['STARRS_USER'], vm.get_mac(), ip)
         set_job_status(job, 'setting VM expiration')
         get_vm_expire(db, vmid, app.config['VM_EXPIRE_MONTHS'])
+        vm.set_boot_order(['Hard Disk', 'CD-ROM', 'Network'])
         logging.info('[{}] VM successfully provisioned.'.format(name))
         set_job_status(job, 'complete')
 


### PR DESCRIPTION
A couple of misc fixes:
- Rename get_boot_order -> set_boot_order
- Fix config.local.py in tasks

And fixing the `KeyError 'o'` we've been seeing:
- Override boot order defaults on vm creation

This is absolutely a workaround, since this sort of boot ordering is deprecated. See the [qm conf file docs](https://pve.proxmox.com/wiki/Manual:_qm.conf) for the newer formatting. I'll throw up an issue for this.
