### PR TITLE
Increase default limits for new proxmox and ceph

### DIFF
--- a/proxstar/db.py
+++ b/proxstar/db.py
@@ -68,9 +68,9 @@ def get_user_usage_limits(db, user):
         limits['mem'] = db.query(Usage_Limit).filter(Usage_Limit.id == user).one().mem
         limits['disk'] = db.query(Usage_Limit).filter(Usage_Limit.id == user).one().disk
     else:
-        limits['cpu'] = 4
-        limits['mem'] = 4
-        limits['disk'] = 100
+        limits['cpu'] = 6
+        limits['mem'] = 8
+        limits['disk'] = 250
     return limits
 
 


### PR DESCRIPTION
Increase default available usage to 6 CPU cores, 8GB ram, and 250gb of storage

We now have huge ram capacity in Proxmox, double the CPU capacity, and more than double ceph storage