### PR TITLE
Mark schema as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+HACKING/proxstar-postgres/schema/large.sql linguist-generated


### PR DESCRIPTION
Occam's Razor. Instead of compressing the schema, adding another stage to the Postgres container, and needing to mark files as ignored, let's just mark the schema as generated. Thanks @Mstrodl .

Closes #142 