### PR TITLE
Fix vnc target redis crash

### DIFF
--- a/HACKING/launch_env.sh
+++ b/HACKING/launch_env.sh
@@ -3,4 +3,4 @@ podman run --rm -d --network=proxstar --name=proxstar-redis redis:alpine
 podman run --rm -d --network=proxstar --name=proxstar-postgres -e POSTGRES_PASSWORD=changeme -v ./HACKING/proxstar-postgres/volume:/var/lib/postgresql/data:Z proxstar-postgres
 podman run --rm -d --network=proxstar --name=proxstar-rq-scheduler  --env-file=HACKING/.env --entrypoint ./start_scheduler.sh proxstar
 podman run --rm -d --network=proxstar --name=proxstar-rq  --env-file=HACKING/.env --entrypoint ./start_worker.sh proxstar
-podman run --rm -it --network=proxstar --name=proxstar -p 8000:8000 -p 8081:8081 --env-file=HACKING/.env --entrypoint='["gunicorn", "proxstar:app", "--bind=0.0.0.0:8000"]' proxstar
+podman run --rm -it --network=proxstar --name=proxstar -p 8000:8000 -p 8001:8001 --env-file=HACKING/.env --entrypoint='["gunicorn", "proxstar:app", "--bind=0.0.0.0:8000"]' proxstar

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -254,7 +254,7 @@ def vm_power(vmid, action):
         vm = VM(vmid)
         vnc_token_key = f'vnc_token|{vmid}'
         # For deleting the token from redis later
-        try: 
+        try:
             vnc_token = redis_conn.get(vnc_token_key).decode('utf-8')
         except AttributeError as e:
             print(f'Error: Could not get vnc_token:{e}')

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -254,7 +254,10 @@ def vm_power(vmid, action):
         vm = VM(vmid)
         vnc_token_key = f'vnc_token|{vmid}'
         # For deleting the token from redis later
-        vnc_token = redis_conn.get(vnc_token_key).decode('utf-8')
+        try: 
+            vnc_token = redis_conn.get(vnc_token_key).decode('utf-8')
+        except AttributeError as e:
+            print(f'Error: Could not get vnc_token:{e}')
         if action == 'start':
             vmconfig = vm.config
             usage_check = user.check_usage(vmconfig['cores'], vmconfig['memory'], 0)


### PR DESCRIPTION
There's a thing that checks for a VMID when starting/stopping/etc-ing a VM. It raises an exception that isn't caught right now. This'll catch it and hopefully stop fucking everything up.

```
2022-08-25 20:33:27,211 ERROR Exception on /vm/118/power/start [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.8/site-packages/ddtrace/contrib/flask/helpers.py", line 25, in wrapper
    return func(pin, wrapped, instance, args, kwargs)
  File "/usr/local/lib/python3.8/site-packages/ddtrace/contrib/flask/helpers.py", line 36, in wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/site-packages/ddtrace/contrib/flask/helpers.py", line 25, in wrapper
    return func(pin, wrapped, instance, args, kwargs)
  File "/usr/local/lib/python3.8/site-packages/ddtrace/contrib/flask/patch.py", line 481, in _traced_request
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.8/site-packages/ddtrace/contrib/flask/wrappers.py", line 25, in trace_func
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/flask_pyoidc/flask_pyoidc.py", line 253, in wrapper
    return view_func(*args, **kwargs)
  File "/opt/proxstar/proxstar/__init__.py", line 257, in vm_power
    vnc_token = redis_conn.get(vnc_token_key).decode('utf-8')
AttributeError: 'NoneType' object has no attribute 'decode'
```