### PR TITLE
Add env var to specify websockify container port

### DIFF
--- a/config.py
+++ b/config.py
@@ -62,6 +62,7 @@ WEBSOCKIFY_PATH = environ.get('PROXSTAR_WEBSOCKIFY_PATH', '/usr/local/bin/websoc
 WEBSOCKIFY_TARGET_FILE = environ.get('PROXSTAR_WEBSOCKIFY_TARGET_FILE', '/opt/proxstar/targets')
 VNC_HOST = environ.get('PROXSTAR_VNC_HOST', 'proxstar-vnc.csh.rit.edu')
 VNC_PORT = environ.get('PROXSTAR_VNC_PORT', '443')
+WEBSOCKIFY_PORT = environ.get('PROXSTAR_WEBSOCKIFY_PORT', '8081')
 
 # SENTRY
 # If you set the sentry dsn locally, make sure you use the local-dev or some

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -16,7 +16,7 @@ def start_websockify(websockify_path, target_file):
     result = subprocess.run(['pgrep', 'websockify'], stdout=subprocess.PIPE)
     if not result.stdout:
         print("Websockify is stopped. Starting websockify.")
-        proxstar_port = app.config.get('VNC_PORT')
+        proxstar_port = app.config.get('WEBSOCKIFY_PORT')
         subprocess.call(
             [
                 websockify_path,


### PR DESCRIPTION
We need one to give to the JS client, and one to actually launch websockify with.