### PR TITLE
Make RTP View Not Awful

### DIFF
--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -200,7 +200,7 @@ def list_vms(user_view=None):
     return render_template('list_vms.html', user=user, user_view=user_view, vms=vms)
 
 
-@app.route("/pools")
+@app.route('/pools')
 def list_pools():
     user = User(session['userinfo']['preferred_username'])
     if app.config['FORCE_STANDARD_USER']:

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -199,6 +199,7 @@ def list_vms(user_view=None):
             vms = 'INACTIVE'
     return render_template('list_vms.html', user=user, user_view=user_view, vms=vms)
 
+
 @app.route("/pools")
 def list_pools():
     user = User(session['userinfo']['preferred_username'])
@@ -209,6 +210,7 @@ def list_pools():
     connect_proxmox()
     vms = get_pool_cache(db)
     return render_template('list_pools.html', user=user, vms=vms)
+
 
 @app.route('/isos')
 @auth.oidc_auth

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -197,7 +197,7 @@ def list_vms(user_view=None):
                     vms.append(pending_vm)
         else:
             vms = 'INACTIVE'
-    return render_template('list_vms.html', user=user, rtp_view=False, vms=vms)
+    return render_template('list_vms.html', user=user, user_view=user_view, vms=vms)
 
 @app.route("/pools")
 def list_pools():
@@ -208,7 +208,7 @@ def list_pools():
         abort(403)
     connect_proxmox()
     vms = get_pool_cache(db)
-    return render_template('list_vms.html', user=user, rtp_view=True, vms=vms)
+    return render_template('list_pools.html', user=user, rtp_view=True, vms=vms)
 
 @app.route('/isos')
 @auth.oidc_auth

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -208,7 +208,7 @@ def list_pools():
         abort(403)
     connect_proxmox()
     vms = get_pool_cache(db)
-    return render_template('list_pools.html', user=user, rtp_view=True, vms=vms)
+    return render_template('list_pools.html', user=user, vms=vms)
 
 @app.route('/isos')
 @auth.oidc_auth

--- a/proxstar/templates/base.html
+++ b/proxstar/templates/base.html
@@ -56,6 +56,12 @@
                     </li>
                     {% if user.rtp %}
                     <li class="nav-item navbar-user dropdown">
+                        <a class="nav-link" href="/pools">
+                            <i class="fas fa-user"></i>
+                            User Pools
+                        </a>
+                    </li>
+                    <li class="nav-item navbar-user dropdown">
                         <a class="nav-link" href="/rq">
                             <i class="fas fa-tachometer-alt"></i>
                             RQ Dashboard

--- a/proxstar/templates/list_pools.html
+++ b/proxstar/templates/list_pools.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+{% block body %}
+
+<div class="container">
+    <div class="row">
+        {% for pool in vms %}
+            <div class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
+                <div class="card bg-light mb-3">
+                    <div class="card-header text-center">
+                        <img class="user-img float-left" src="https://profiles.csh.rit.edu/image/{{ pool['user'] }}" title="{{ pool['user'] }}">
+                        <h5 class="card-title user-title">
+                            <a href="/user/{{ pool['user'] }}">
+                                {{ pool['user'] }}
+                            </a>
+                        </h5>
+                        <span class="float-right">{{ pool['num_vms'] }}</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="resource-bar">
+                            <span class="float-left">CPU</span>
+                            <div class="progress" data-toggle="tooltip" title="{{ pool['usage']['cpu'] }}/{{ pool['limits']['cpu'] }}">
+                                {% if pool['percents']['cpu'] <= 60 %}
+                                <div class="progress-bar bg-success" role="progressbar" aria-valuenow="{{ pool['percents']['cpu'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['cpu'] }}%"></div>
+                                {% elif pool['percents']['cpu'] <= 80 %}
+                                <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="{{ pool['percents']['cpu'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['cpu'] }}%"></div>
+                                {% else %}
+                                <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="{{ pool['percents']['cpu'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['cpu'] }}%"></div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div class="resource-bar">
+                            <span class="float-left">MEM</span>
+                            <div class="progress" data-toggle="tooltip" title="{{ pool['usage']['mem'] }}GB/{{ pool['limits']['mem'] }}.0GB">
+                                {% if pool['percents']['mem'] <= 60 %}
+                                <div class="progress-bar bg-success" role="progressbar" aria-valuenow="{{ pool['percents']['mem'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['mem'] }}%"></div>
+                                {% elif pool['percents']['mem'] <= 80 %}
+                                <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="{{ pool['percents']['mem'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['mem'] }}%"></div>
+                                {% else %}
+                                <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="{{ pool['percents']['mem'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['mem'] }}%"></div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div class="resource-bar">
+                            <span class="float-left">DISK</span>
+                            <div class="progress" data-toggle="tooltip" title="{{ pool['usage']['disk'] }}GB/{{ pool['limits']['disk'] }}GB">
+                                {% if pool['percents']['disk'] <= 60 %}
+                                <div class="progress-bar bg-success" role="progressbar" aria-valuenow="{{ pool['percents']['disk'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['disk'] }}%"></div>
+                                {% elif pool['percents']['disk'] <= 80 %}
+                                <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="{{ pool['percents']['disk'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['disk'] }}%"></div>
+                                {% else %}
+                                <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="{{ pool['percents']['disk'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['disk'] }}%"></div>
+                                {% endif %}
+                            </div>
+                        </div>
+                        <div class="text-center">
+                            <button class="btn btn-info proxstar-poolbtn edit-limit" data-user="{{ pool['user'] }}" data-cpu="{{ pool['limits']['cpu'] }}" data-mem="{{ pool['limits']['mem'] }}" data-disk="{{ pool['limits']['disk'] }}">EDIT</button>
+                            {% if not pool['vms'] %}
+                            <button class="btn btn-danger proxstar-poolbtn delete-user" data-user="{{ pool['user'] }}">DELETE</button>
+                        {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+</div>
+
+{% endblock %}

--- a/proxstar/templates/list_vms.html
+++ b/proxstar/templates/list_vms.html
@@ -3,11 +3,11 @@
 
 <div class="container">
     <div class="row">
-        {% if user['rtp'] and rtp_view != True %}
+        {% if user_view %}
         <div class="col-md-12 col-sm-12">
             <div class="card bg-light mb-3">
                 <div class="card-header text-center">
-                    <h5 class="card-title">{{ rtp_view }}</h5>
+                    <h5 class="card-title">{{ user_view.name }}</h5>
                 </div>
             </div>
         </div>
@@ -28,7 +28,7 @@
                 </div>
             </div>
         </div>
-        {% elif rtp_view != True %}
+        {% else %}
             {% for vm in vms %}
                 <div class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
                     <div class="card bg-light mb-3">
@@ -41,66 +41,6 @@
                             <p>{{ vm['name'] }}</p>
                             {% endif %}
                             <p>Status: {{ vm['status'] }}</p>
-                        </div>
-                    </div>
-                </div>
-            {% endfor %}
-        {% else %}
-            {% for pool in vms %}
-                <div class="col-lg-3 col-md-4 col-sm-6 col-xs-12">
-                    <div class="card bg-light mb-3">
-                        <div class="card-header text-center">
-                            <img class="user-img float-left" src="https://profiles.csh.rit.edu/image/{{ pool['user'] }}" title="{{ pool['user'] }}">
-                            <h5 class="card-title user-title">
-                                <a href="/user/{{ pool['user'] }}">
-                                    {{ pool['user'] }}
-                                </a>
-                            </h5>
-                            <span class="float-right">{{ pool['num_vms'] }}</span>
-                        </div>
-                        <div class="card-body">
-                            <div class="resource-bar">
-                                <span class="float-left">CPU</span>
-                                <div class="progress" data-toggle="tooltip" title="{{ pool['usage']['cpu'] }}/{{ pool['limits']['cpu'] }}">
-                                    {% if pool['percents']['cpu'] <= 60 %}
-                                    <div class="progress-bar bg-success" role="progressbar" aria-valuenow="{{ pool['percents']['cpu'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['cpu'] }}%"></div>
-                                    {% elif pool['percents']['cpu'] <= 80 %}
-                                    <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="{{ pool['percents']['cpu'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['cpu'] }}%"></div>
-                                    {% else %}
-                                    <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="{{ pool['percents']['cpu'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['cpu'] }}%"></div>
-                                    {% endif %}
-                                </div>
-                            </div>
-                            <div class="resource-bar">
-                                <span class="float-left">MEM</span>
-                                <div class="progress" data-toggle="tooltip" title="{{ pool['usage']['mem'] }}GB/{{ pool['limits']['mem'] }}.0GB">
-                                    {% if pool['percents']['mem'] <= 60 %}
-                                    <div class="progress-bar bg-success" role="progressbar" aria-valuenow="{{ pool['percents']['mem'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['mem'] }}%"></div>
-                                    {% elif pool['percents']['mem'] <= 80 %}
-                                    <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="{{ pool['percents']['mem'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['mem'] }}%"></div>
-                                    {% else %}
-                                    <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="{{ pool['percents']['mem'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['mem'] }}%"></div>
-                                    {% endif %}
-                                </div>
-                            </div>
-                            <div class="resource-bar">
-                                <span class="float-left">DISK</span>
-                                <div class="progress" data-toggle="tooltip" title="{{ pool['usage']['disk'] }}GB/{{ pool['limits']['disk'] }}GB">
-                                    {% if pool['percents']['disk'] <= 60 %}
-                                    <div class="progress-bar bg-success" role="progressbar" aria-valuenow="{{ pool['percents']['disk'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['disk'] }}%"></div>
-                                    {% elif pool['percents']['disk'] <= 80 %}
-                                    <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="{{ pool['percents']['disk'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['disk'] }}%"></div>
-                                    {% else %}
-                                    <div class="progress-bar bg-danger" role="progressbar" aria-valuenow="{{ pool['percents']['disk'] }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ pool['percents']['disk'] }}%"></div>
-                                    {% endif %}
-                                </div>
-                            </div>
-                            <div class="text-center">
-                                <button class="btn btn-info proxstar-poolbtn edit-limit" data-user="{{ pool['user'] }}" data-cpu="{{ pool['limits']['cpu'] }}" data-mem="{{ pool['limits']['mem'] }}" data-disk="{{ pool['limits']['disk'] }}">EDIT</button>
-                                {% if not pool['vms'] %}
-                                <button class="btn btn-danger proxstar-poolbtn delete-user" data-user="{{ pool['user'] }}">DELETE</button>
-                            {% endif %}
-                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
We don't need to see all user pools on login. Let us see our VMs and moves the pools to a different route (with a button up top)
![image](https://user-images.githubusercontent.com/40615740/188971046-3dc428fe-2579-43b1-8f71-0c275a75d937.png)
![image](https://user-images.githubusercontent.com/40615740/188971060-576f56b4-f8e1-4be4-bb3a-45f6bc0cccb4.png)
![image](https://user-images.githubusercontent.com/40615740/188971077-584d6878-841e-499d-b300-4eacba5b416f.png)
