### PR TITLE
Impose limits on all VM creation

### DIFF
--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -485,16 +485,13 @@ def create():
             if iso != 'none':
                 iso = '{}:iso/{}'.format(app.config['PROXMOX_ISO_STORAGE'], iso)
             if not user.rtp:
-                if template == 'none':
-                    usage_check = user.check_usage(0, 0, disk)
-                else:
-                    usage_check = user.check_usage(cores, memory, disk)
+                usage_check = user.check_usage(cores, memory, disk)
                 username = user.name
             else:
                 usage_check = None
                 username = request.form['user']
             if usage_check:
-                return usage_check
+                return usage_check, 403
             else:
                 valid, available = (
                     check_hostname(starrs, name) if app.config['USE_STARRS'] else (True, True)

--- a/proxstar/static/js/script.js
+++ b/proxstar/static/js/script.js
@@ -284,9 +284,9 @@ $("#create-vm").click(function(){
                 swal("Uh oh...", "Invalid SSH key!", "error");
             } else if (disk > max_disk) {
                 swal("Uh oh...", `You do not have enough disk resources available! Please lower the VM disk size to ${max_disk}GB or lower.`, "error");
-            } else if (template != 'none' && cores > max_cpu) {
+            } else if (cores > max_cpu) {
                 swal("Uh oh...", `You do not have enough CPU resources available! Please lower the VM cores to ${max_cpu} or lower.`, "error");
-            } else if (template != 'none' && mem/1024 > max_mem) {
+            } else if (mem/1024 > max_mem) {
                 swal("Uh oh...", `You do not have enough memory resources available! Please lower the VM memory to ${max_mem}GB or lower.`, "error");
             } else {
                 fetch(`/hostname/${name}`, {


### PR DESCRIPTION
This prevents people from trying to allocate more resources than they have available in total. This isn't the best solution, since it may prevent people from having many VMs with only a few started up, but that's a problem for when users start complaining.