### PR TITLE
Add button to manually run the `Cleanup VNC sessions` task

### DIFF
--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -568,6 +568,8 @@ def settings():
             templates=templates,
             ignored_pools=db_ignored_pools,
             allowed_users=db_allowed_users,
+            vnc_cleanup_token=app.config['VNC_CLEANUP_TOKEN'],
+            server_name=app.config['SERVER_NAME']
         )
     else:
         return abort(403)

--- a/proxstar/static/js/script.js
+++ b/proxstar/static/js/script.js
@@ -627,6 +627,31 @@ $(".add-ignored-pool").click(function(){
     });
 });
 
+$("#generate-pool-cache-task-button").click(function(){
+
+});
+
+$("#process-expiring-vms-task-button").click(function(){
+});
+
+$("#cleanup-vnc-task-button").click(function(){
+    const vncCleanupToken = $(this).data('vnc_cleanup_token');
+//    let data = {'token': vncCleanupToken};
+
+    console.log(vncCleanupToken);
+
+    var formData = new FormData();
+    formData.append('token', vncCleanupToken);
+    fetch(`/console/cleanup`, {
+      method: 'post',
+      credentials: 'same-origin',
+      body: formData 
+    }).then(res => {
+      console.log("Request complete! response:", res);
+    });
+});
+
+
 function change_for_template(obj) {
     var template_element = obj;
     var selected = template_element.options[template_element.selectedIndex].value;
@@ -653,7 +678,6 @@ $("#console-vm").click(function(){
         return response.json()
     }).then((vnc_params) => {
         // TODO (willnilges): encrypt=true
-        // TODO (willnilges): set host and port to an env variable
         window.open(`/static/noVNC/vnc.html?autoconnect=true&password=${vnc_params.password}&host=${vnc_params.host}&port=${vnc_params.port}&path=path?token=${vnc_params.token}`, '_blank');
     }).catch(err => {
         if (err) {

--- a/proxstar/static/js/script.js
+++ b/proxstar/static/js/script.js
@@ -627,12 +627,14 @@ $(".add-ignored-pool").click(function(){
     });
 });
 
+// TODO: Move these tasks so they're callable via JS?
+/*
 $("#generate-pool-cache-task-button").click(function(){
-
 });
 
 $("#process-expiring-vms-task-button").click(function(){
 });
+*/
 
 $("#cleanup-vnc-task-button").click(function(){
     const vncCleanupToken = $(this).data('vnc_cleanup_token');

--- a/proxstar/static/js/script.js
+++ b/proxstar/static/js/script.js
@@ -636,18 +636,44 @@ $("#process-expiring-vms-task-button").click(function(){
 
 $("#cleanup-vnc-task-button").click(function(){
     const vncCleanupToken = $(this).data('vnc_cleanup_token');
-//    let data = {'token': vncCleanupToken};
-
-    console.log(vncCleanupToken);
-
-    var formData = new FormData();
-    formData.append('token', vncCleanupToken);
-    fetch(`/console/cleanup`, {
-      method: 'post',
-      credentials: 'same-origin',
-      body: formData 
-    }).then(res => {
-      console.log("Request complete! response:", res);
+    
+    swal({
+        title: "Are you sure you want to clear VNC tokens?",
+        text: "This will clear the websockify targets file, and remove all entries from Redis. Ongoing VNC sessions may be disrupted.",
+        icon: "warning",
+        buttons: {
+            cancel: true,
+            action: {
+                text: "Cleanup VNC Sessions",
+                closeModal: false,
+                className: "swal-button--danger",
+            }
+        },
+        dangerMode: true,
+    })
+    .then((willComplete) => {
+        if (willComplete) {
+            var formData = new FormData();
+            formData.append('token', vncCleanupToken);
+            fetch(`/console/cleanup`, {
+              method: 'post',
+              credentials: 'same-origin',
+              body: formData 
+            }).then((response) => {
+                return swal("VNC Sessions have been cleared", {
+                    icon: "success",
+                });
+            }).then(() => {
+                window.location = location;
+            }).catch(err => {
+                if (err) {
+                    swal("Uh oh...", "Unable to clear VNC sessions", "error");
+                } else {
+                    swal.stopLoading();
+                    swal.close();
+                }
+            });
+        }
     });
 });
 

--- a/proxstar/templates/settings.html
+++ b/proxstar/templates/settings.html
@@ -114,10 +114,11 @@
             </div>
         </div>
         <div class="panel-body">
-
-         
-            <button class="btn btn-secondary" id="generate-pool-cache-task-button" name="generate-pool-cache-task-button" >GENERATE POOL CACHE</button>
-            <button class="btn btn-secondary" id="process-expiring-vms-task-button" name="process-expiring-vms-task-button">PROCESS EXPIRING VMS</button>
+            <!--TODO: Expose these functions through Flask so that they can be called with the API-->
+            <!--
+                <button class="btn btn-secondary" id="generate-pool-cache-task-button" name="generate-pool-cache-task-button" >GENERATE POOL CACHE</button>
+                <button class="btn btn-secondary" id="process-expiring-vms-task-button" name="process-expiring-vms-task-button">PROCESS EXPIRING VMS</button>
+            -->
             <button class="btn btn-secondary" id="cleanup-vnc-task-button" name="cleanup-vnc-task-button" data-vnc_cleanup_token="{{ vnc_cleanup_token }}" data-server_name="{{ server_name }}">CLEANUP VNC SESSIONS</button>
         </div>
     </div>

--- a/proxstar/templates/settings.html
+++ b/proxstar/templates/settings.html
@@ -113,6 +113,13 @@
                 </div>
             </div>
         </div>
+        <div class="panel-body">
+
+         
+            <button class="btn btn-secondary" id="generate-pool-cache-task-button" name="generate-pool-cache-task-button" >GENERATE POOL CACHE</button>
+            <button class="btn btn-secondary" id="process-expiring-vms-task-button" name="process-expiring-vms-task-button">PROCESS EXPIRING VMS</button>
+            <button class="btn btn-secondary" id="cleanup-vnc-task-button" name="cleanup-vnc-task-button" data-vnc_cleanup_token="{{ vnc_cleanup_token }}" data-server_name="{{ server_name }}">CLEANUP VNC SESSIONS</button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Adds a button that clears the websockify targets file and clears the Redis cache. Might be useful for development (I've had to manually `curl` too many times.

TODO: Add other functions, also need to ensure that we're not leaking the VNC cleanup token.