### PR TITLE
Use Proxmoxer for VNC Port and Ticket

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 from flask import Flask
+
 app = Flask(__name__)
 if os.path.exists(os.path.join(app.config.get('ROOT_DIR', os.getcwd()), "config_local.py")):
     config = os.path.join(app.config.get('ROOT_DIR', os.getcwd()), "config_local.py")

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -331,12 +331,12 @@ def vm_power(vmid, action):
 @auth.oidc_auth
 def vm_console(vmid):
     user = User(session['userinfo']['preferred_username'])
-    connect_proxmox()
+    proxmox = connect_proxmox()
     if user.rtp or int(vmid) in user.allowed_vms:
         # import pdb; pdb.set_trace()
         vm = VM(vmid)
         vnc_ticket, vnc_port = open_vnc_session(
-            vmid, vm.node, app.config['PROXMOX_USER'], app.config['PROXMOX_PASS']
+            vmid, vm.node, proxmox
         )
         node = f'{vm.node}.csh.rit.edu'
         token = add_vnc_target(node, vnc_port)

--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -335,9 +335,7 @@ def vm_console(vmid):
     if user.rtp or int(vmid) in user.allowed_vms:
         # import pdb; pdb.set_trace()
         vm = VM(vmid)
-        vnc_ticket, vnc_port = open_vnc_session(
-            vmid, vm.node, proxmox
-        )
+        vnc_ticket, vnc_port = open_vnc_session(vmid, vm.node, proxmox)
         node = f'{vm.node}.csh.rit.edu'
         token = add_vnc_target(node, vnc_port)
         redis_conn.set(f'vnc_token|{vmid}', str(token))  # Store the VNC token in Redis.

--- a/proxstar/vnc.py
+++ b/proxstar/vnc.py
@@ -3,7 +3,6 @@ import subprocess
 import time
 import urllib.parse
 
-import requests
 from flask import current_app as app
 
 from proxstar import logging
@@ -85,4 +84,4 @@ def open_vnc_session(vmid, node, proxmox):
     params = {'websocket': '1', 'generate-password': '0'}
     vncproxy_response_data = proxmox.nodes(node).qemu(str(vmid)).vncproxy.post(**params)
 
-    return urllib.parse.quote_plus(vncproxy_response_data['ticket']) vncproxy_response_data['port']
+    return urllib.parse.quote_plus(vncproxy_response_data['ticket']), vncproxy_response_data['port']

--- a/proxstar/vnc.py
+++ b/proxstar/vnc.py
@@ -74,36 +74,15 @@ def delete_vnc_target(node=None, port=None, token=None):
         raise LookupError('Target does not exist')
 
 
-def open_vnc_session(vmid, node, proxmox_user, proxmox_pass):
+def open_vnc_session(vmid, node, proxmox):
     """Pings the Proxmox API to request a VNC Proxy connection. Authenticates
     against the API using a Uname/Pass, gets a few tokens back, then uses those
     tokens to  open the VNC Proxy. Use these to connect to the VM's host with
     websockify proxy.
     Returns: Ticket to use as the noVNC password, and a port.
     """
-    # Get Proxmox API ticket and CSRF_Prevention_Token
-    # TODO (willnilges): Use Proxmoxer to get this information
     # TODO (willnilges): Report errors
-    data = {'username': proxmox_user, 'password': proxmox_pass}
-    response_data = requests.post(
-        f'https://{node}.csh.rit.edu:8006/api2/json/access/ticket',
-        verify=False,
-        data=data,
-    ).json()['data']
-    if response_data is None:
-        raise requests.AuthenticationError(
-            'Could not authenticate against `ticket` endpoint! Check uname/password'
-        )
-    csrf_prevention_token = response_data['CSRFPreventionToken']
-    ticket = response_data['ticket']
-    proxy_params = {'node': node, 'vmid': str(vmid), 'websocket': '1', 'generate-password': '0'}
-    vncproxy_response_data = requests.post(
-        f'https://{node}.csh.rit.edu:8006/api2/json/nodes/{node}/qemu/{vmid}/vncproxy',
-        verify=False,
-        timeout=5,
-        params=proxy_params,
-        headers={'CSRFPreventionToken': csrf_prevention_token},
-        cookies={'PVEAuthCookie': ticket},
-    ).json()['data']
+    params = {'websocket': '1', 'generate-password': '0'}
+    vncproxy_response_data = proxmox.nodes(node).qemu(str(vmid)).vncproxy.post(**params)
 
-    return urllib.parse.quote_plus(vncproxy_response_data['ticket']), vncproxy_response_data['port']
+    return urllib.parse.quote_plus(vncproxy_response_data['ticket']) vncproxy_response_data['port']


### PR DESCRIPTION
Proxmoxer is now used for the VNC Proxy openings instead of a raw post request