### PR TITLE
Use correct node in API call

### DIFF
--- a/proxstar/__init__.py
+++ b/proxstar/__init__.py
@@ -335,6 +335,7 @@ def vm_console(vmid):
     if user.rtp or int(vmid) in user.allowed_vms:
         # import pdb; pdb.set_trace()
         vm = VM(vmid)
+        proxmox = connect_proxmox(f'{vm.node}.csh.rit.edu')
         vnc_ticket, vnc_port = open_vnc_session(vmid, vm.node, proxmox)
         node = f'{vm.node}.csh.rit.edu'
         token = add_vnc_target(node, vnc_port)

--- a/proxstar/proxmox.py
+++ b/proxstar/proxmox.py
@@ -8,33 +8,33 @@ from proxstar.ldapdb import is_user
 
 def connect_proxmox(host=None):
     if host:
-        attempted_connection = attempt_proxmox_connection(host)
-        if attempted_connection:
-            return attempted_connection
-        logging.error(f'unable to connect to {host}')
-        raise
+        try:
+            return attempt_proxmox_connection(host)
+        except:
+            logging.error(f'unable to connect to {host}')
+            raise
 
-    for host in app.config['PROXMOX_HOSTS']:
-        attempted_connection = attempt_proxmox_connection(host)
-        if attempted_connection:
-            return attempted_connection
-    logging.error('unable to connect to any of the given Proxmox servers')
-    raise
+    for host_candidate in app.config['PROXMOX_HOSTS']:
+        try:
+            return attempt_proxmox_connection(host_candidate)
+        except:
+            if app.config['PROXMOX_HOSTS'].index(host_candidate) == (
+                len(app.config['PROXMOX_HOSTS']) - 1
+            ):
+                logging.error('unable to connect to any of the given Proxmox servers')
+                raise
 
 
 def attempt_proxmox_connection(host):
-    try:
-        proxmox = ProxmoxAPI(
-            host,
-            user=app.config['PROXMOX_USER'],
-            token_name=app.config['PROXMOX_TOKEN_NAME'],
-            token_value=app.config['PROXMOX_TOKEN_VALUE'],
-            verify_ssl=False,
-        )
-        proxmox.version.get()
-        return proxmox
-    except:
-        return None
+    proxmox = ProxmoxAPI(
+        host,
+        user=app.config['PROXMOX_USER'],
+        token_name=app.config['PROXMOX_TOKEN_NAME'],
+        token_value=app.config['PROXMOX_TOKEN_VALUE'],
+        verify_ssl=False,
+    )
+    proxmox.version.get()
+    return proxmox
 
 
 def get_node_least_mem(proxmox):


### PR DESCRIPTION
My brain doesn't works sometimes. In the old version before my last PR, the request was made directly to the node that the VM was on. Proxmoxer didn't care who authenticated it so it was opening VNC sessions on random hosts. They were made, but then the code tried to open the websockify on the node the VM was on and it was often saying "uhhhhh I'm not open chief". Now it specifies where it wants to authenticate in that route so the open port and VM host are the same device.

IT ACTUALLY ACTUALLY WORKS IN TESTING