### PR TITLE
Fix 500 on IDE Drives

### DIFF
--- a/proxstar/user.py
+++ b/proxstar/user.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 from proxmoxer.core import ResourceException
 from rq.registry import StartedJobRegistry
 
@@ -88,7 +90,7 @@ class User:
                     usage['cpu'] += int(vm.cpu)
                     usage['mem'] += int(vm.mem) / 1024
                 for disk in vm.disks:
-                    usage['disk'] += int(disk[1])
+                    usage['disk'] += int(ceil(disk[1]))
         return usage
 
     @lazy_property

--- a/proxstar/vm.py
+++ b/proxstar/vm.py
@@ -10,6 +10,10 @@ from proxstar.proxmox import connect_proxmox, get_free_vmid, get_node_least_mem,
 from proxstar.starrs import get_ip_for_mac
 from proxstar.util import lazy_property, default_repr
 
+def check_in_gb(size):
+    if size[-1] == 'M':
+        size = f'{int(size.rstrip("M")) / 1000}G'
+    return size
 
 @default_repr
 class VM:
@@ -250,11 +254,6 @@ class VM:
             if 'size' in split:
                 disk_size = split.split('=')[1].rstrip('G')
         return disk_size
-
-    def check_in_gb(size):
-        if size[-1] == 'M':
-            size = f'{int(size.rstrip("M")) / 1000}G'
-        return size
 
     @lazy_property
     def disks(self):

--- a/proxstar/vm.py
+++ b/proxstar/vm.py
@@ -251,6 +251,11 @@ class VM:
                 disk_size = split.split('=')[1].rstrip('G')
         return disk_size
 
+    def check_in_gb(size):
+        if size[-1] == 'M':
+            size = f'{int(size.rstrip("M")) / 1000}G'
+        return size
+
     @lazy_property
     def disks(self):
         disks = []
@@ -261,9 +266,7 @@ class VM:
                     disk_size = val.split(',')
                     for split in disk_size:
                         if 'size' in split:
-                            size = split.split('=')[1]
-                            if size[-1] == 'M':
-                                size = f'{int(size.rstrip("M")) / 1000}G'
+                            size = check_in_gb(split.split('=')[1])
                             disk_size = size.rstrip('G')
                     disks.append([key, disk_size])
         disks = sorted(disks, key=lambda x: x[0])

--- a/proxstar/vm.py
+++ b/proxstar/vm.py
@@ -10,10 +10,12 @@ from proxstar.proxmox import connect_proxmox, get_free_vmid, get_node_least_mem,
 from proxstar.starrs import get_ip_for_mac
 from proxstar.util import lazy_property, default_repr
 
+
 def check_in_gb(size):
     if size[-1] == 'M':
         size = f'{int(size.rstrip("M")) / 1000}G'
     return size
+
 
 @default_repr
 class VM:

--- a/proxstar/vm.py
+++ b/proxstar/vm.py
@@ -261,7 +261,10 @@ class VM:
                     disk_size = val.split(',')
                     for split in disk_size:
                         if 'size' in split:
-                            disk_size = split.split('=')[1].rstrip('G')
+                            size = split.split('=')[1]
+                            if size[-1] == 'M':
+                                size = f'{int(size.rstrip("M")) / 1000}G'
+                            disk_size = size.rstrip('G')
                     disks.append([key, disk_size])
         disks = sorted(disks, key=lambda x: x[0])
         return disks
@@ -280,11 +283,10 @@ class VM:
     @lazy_property
     def isos(self):
         isos = []
-        for iso in filter(lambda interface: 'ide' in interface, self.config.keys()):
+        for iso in filter(lambda interface: interface in self.cdroms, self.config.keys()):
             iso_info = self.config[iso]
             if iso_info:
                 if 'cloudinit' in iso_info:
-                    isos.append((iso, 'Clountinit Drive'))
                     continue
                 if iso_info.split(',')[0] == 'none':
                     isos.append((iso, 'None'))


### PR DESCRIPTION
If you try and open a VM that has an IDE drive (not VirtIO), it crashes because it thinks its an ISO and tries to parse it as such.

This wasn't an issue before until Cloud Init Windows, which only wants IDE drives or it shoots itself in the foot.